### PR TITLE
Auto download eigen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,20 @@ if(NOT EXISTS ${PROJECT_SOURCE_DIR}/${SAKURA_DIR}/${GTEST_DIR})
                   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/${SAKURA_DIR})
 endif()
 
+# download Eigen
+set(EIGEN_DIR eigen-3.3.7)
+set(EIGEN_TAR eigen-3.3.7.tar.bz2)
+if(NOT EXISTS ${PROJECT_SOURCE_DIR}/${EIGEN_DIR})
+  if(NOT EXISTS ${CMAKE_BINARY_DIR}/${EIGEN_TAR})
+    message(STATUS "Eigen is not downloaded yet")
+    set(EIGEN_URL https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.bz2)
+    execute_process(COMMAND curl -L -O ${EIGEN_URL}
+                    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+  endif()
+  execute_process(COMMAND tar jxf ${CMAKE_BINARY_DIR}/${EIGEN_TAR}
+                  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+endif()
+
 # configure sakura
 # edit configuration files for sakura
 execute_process(COMMAND sed -i -e "/^add_subdirectory.g*test/d" CMakeLists.txt
@@ -114,6 +128,7 @@ foreach(SAKURA_SUBDIR IN ITEMS src python-binding)
 endforeach()
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/${SAKURA_DIR}/cmake-modules CACHE STRING "List of directories to search for CMake modules")
 set(BUILD_DOC OFF CACHE BOOL "Build Sakura API document")
+set(EIGEN3_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/${EIGEN_DIR})
 if (APPLE)
   set(CMAKE_INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/priism/external/sakura")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ if(NOT EXISTS ${PROJECT_SOURCE_DIR}/${SAKURA_DIR})
     execute_process(COMMAND curl -L -O ${SAKURA_URL}
                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   endif()
-  execute_process(COMMAND tar zxvf ${CMAKE_BINARY_DIR}/${SAKURA_TAR}
+  execute_process(COMMAND tar zxf ${CMAKE_BINARY_DIR}/${SAKURA_TAR}
                   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ endif()
 set(SAKURA_DIR libsakura)
 set(SAKURA_TAR libsakura-5.0.8.tgz)
 if(NOT EXISTS ${PROJECT_SOURCE_DIR}/${SAKURA_DIR})
-  if(NOT EXISTS ${PROJECT_SOURCE_DIR}/${SAKURA_TAR})
+  if(NOT EXISTS ${CMAKE_BINARY_DIR}/${SAKURA_TAR})
     message(STATUS "Sakura is not downloaded yet")
     set(SAKURA_URL https://alma-intweb.mtk.nao.ac.jp/~nakazato/libsakura/${SAKURA_TAR})
     execute_process(COMMAND curl -L -O ${SAKURA_URL}

--- a/README.md
+++ b/README.md
@@ -110,8 +110,9 @@ available.
 PRIISM for ALMA (`priism.alma`) is supposed to run on CASA or python environment with casa tools. If you want to
 use `priism.alma`, CASA 5.0 or higher must be available.
 
-In addition to the dependency on PRIISM, there are several prerequisites from
-Sakura and sparseimaging libraries: FFTW3 and Eigen3.
+In addition to the dependency on PRIISM, there are prerequisites from
+Sakura and sparseimaging libraries: FFTW3 and Eigen3. 
+Since Eigen3 is automatically downloaded during PRIISM setup, only FFTW3 is the prerequisite for PRIISM.
 More importantly, PRIISM requires C++ compiler that supports C++11 features
 since Sakura and sparseimaging utilizes various C++11 features in its implementation.
 
@@ -123,7 +124,6 @@ In summary, prerequisites for PRIISM is as follows:
 * CASA 5.0 or higher (for `priism.alma`)
 * gcc/g++ 4.8 or higher or clang/clang++ 3.5 or higher
 * FFTW3
-* Eigen 3.2 or higher
 * git (optional but preferable)
 
 
@@ -169,13 +169,6 @@ Available options for cmake is as follows. Syntax for the option is `-D<name>=<v
 This option specifies the directory where to install PRIISM.
 
 Example: `-DCMAKE_INSTALL_PREFIX=/usr/local/priism`
-
-**EIGEN3_INCLUDE_DIR**
-
-This option tells cmake where Eigen3 header files are installed.
-This option will be useful when Eigen3 is installed to non-standard location.
-
-Example: `-DEIGEN3_INCLUDE_DIR=$HOME/eigen`
 
 **PYTHON_ROOTDIR**
 

--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,7 @@ class download_sakura(config):
             raise PriismDependencyError('No download command found: you have to install curl or wget')
 
         self.epilogue_cmds = ['tar zxvf {}'.format(tgzname)]
-        self.epilogut_cwd = '.'
+        self.epilogue_cwd = '.'
         self.package_directory = package
         self.working_directory = self.package_directory
 
@@ -235,7 +235,7 @@ class download_sakura(config):
         if not os.path.exists(self.package_directory):
             execute_command(self.download_cmd)
             for cmd in self.epilogue_cmds:
-                execute_command(cmd, cwd=self.epilogut_cwd)
+                execute_command(cmd, cwd=self.epilogue_cwd)
 
 
 class configure_ext(Command):

--- a/setup.py
+++ b/setup.py
@@ -220,7 +220,7 @@ class download_sakura(config):
         else:
             raise PriismDependencyError('No download command found: you have to install curl or wget')
 
-        self.epilogue_cmds = ['tar zxvf {}'.format(tgzname)]
+        self.epilogue_cmds = ['tar zxf {}'.format(tgzname)]
         self.epilogue_cwd = '.'
         self.package_directory = package
         self.working_directory = self.package_directory

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,6 @@ def initialize_attr_for_user_options(cmd):
 class priism_build(build):
     user_options = [
         ('cxx-compiler=', 'C', 'specify path to C++ compiler'),
-        ('eigen3-include-dir=', 'E', 'specify directory for Eigen3'),
         ('python-root-dir=', 'P', 'specify root directory for Python'),
         ('python-include-dir=', 'I', 'specify include directory for Python.h (take priority over python-root-dir)'),
         ('python-library=', 'L', 'specify Python library (take priority over python-root-dir)'),
@@ -238,6 +237,41 @@ class download_sakura(config):
                 execute_command(cmd, cwd=self.epilogue_cwd)
 
 
+class download_eigen(config):
+    user_options = []
+
+    def initialize_options(self):
+        super(download_eigen, self).initialize_options()
+
+        is_curl_ok, is_wget_ok = check_command_availability(['curl', 'wget'])
+        package = 'eigen'
+        version = '3.3.7'
+        tgzname = '{}-{}.tar.bz2'.format(package, version)
+        url = 'https://gitlab.com/libeigen/eigen/-/archive/{}/{}'.format(version, tgzname)
+        if is_curl_ok:
+            self.download_cmd = 'curl -L -O {}'.format(url)
+        elif is_wget_ok:
+            self.download_cmd = 'wget {}'.format(url)
+        else:
+            raise PriismDependencyError('No download command found: you have to install curl or wget')
+
+        self.epilogue_cmds = ['tar jxf {}'.format(tgzname)]
+        self.epilogue_cwd = '.'
+        self.package_directory = package
+        self.working_directory = self.package_directory
+
+    def finalize_options(self):
+        super(download_eigen, self).finalize_options()
+
+    def run(self):
+        super(download_eigen, self).run()
+
+        if not os.path.exists(self.package_directory):
+            execute_command(self.download_cmd)
+            for cmd in self.epilogue_cmds:
+                execute_command(cmd, cwd=self.epilogue_cwd)
+
+
 class configure_ext(Command):
     user_options = priism_build.user_options
 
@@ -284,9 +318,6 @@ class configure_ext(Command):
         if self.python_library is not None:
             cmd += ' -DPYTHON_LIBRARY={}'.format(self.python_library)
 
-        if self.eigen3_include_dir is not None:
-            cmd += ' -DEIGEN3_INCLUDE_DIR={}'.format(self.eigen3_include_dir)
-
         if self.cxx_compiler is not None:
             cmd += ' -DCMAKE_CXX_COMPILER={}'.format(self.cxx_compiler)
 
@@ -310,7 +341,7 @@ class configure_ext(Command):
         cmd = self.__configure_cmake_command()
         execute_command(cmd, cwd=self.priism_build_dir)
 
-    sub_commands = build_ext.sub_commands + [('download_sakura', None), ('download_smili', None)]
+    sub_commands = build_ext.sub_commands + [('download_sakura', None), ('download_smili', None), ('download_eigen', None)]
 
 
 setup(
@@ -324,6 +355,7 @@ setup(
         'build_ext': priism_build_ext,
         'download_sakura': download_sakura,
         'download_smili': download_smili,
+        'download_eigen': download_eigen,
         'configure_ext': configure_ext,
     }
 )


### PR DESCRIPTION
Build procedure is updated (both cmake and setup.py) so that it downloads latest public release of Eigen (3.3.7) and include it for compile. User will no longer care about Eigen when building PRIISM.