### PR TITLE
Update sparseimaging

### DIFF
--- a/python/priism/core/sparseimagingbase.py
+++ b/python/priism/core/sparseimagingbase.py
@@ -258,7 +258,7 @@ class SparseImagingResults(CTypesUtilMixIn):
         self.xinit = numpy.empty(nn, dtype=numpy.double)
         if initialimage is None:
             # by default, initially all pixels are 1.0
-            self.xinit[:] = 1.0
+            self.xinit[:] = 0.0
         else:
             # initial image is set by the user
             assert isinstance(initialimage, numpy.ndarray) or isinstance(initialimage, list)

--- a/python/priism/core/sparseimagingbase.py
+++ b/python/priism/core/sparseimagingbase.py
@@ -384,7 +384,7 @@ class SparseImagingExecutor(object):
         print('')
         print(' FFTW file:              {0}'.format(inputs.infile))
         if initialimage is None:
-            print(' x was initialized with 1.0')
+            print(' x was initialized with 0.0')
         else:
             print(' x was initialize by the user')
         #print ' x is saved to:          xout'

--- a/python/priism/core/sparseimagingfft.py
+++ b/python/priism/core/sparseimagingfft.py
@@ -196,7 +196,7 @@ class SparseImagingExecutor(object):
         print('')
         print(' FFTW file:              {0}'.format(inputs.infile))
         if initialimage is None:
-            print(' x was initialized with 1.0')
+            print(' x was initialized with 0.0')
         else:
             print(' x was initialize by the user')
         #print ' x is saved to:          xout'

--- a/python/priism/core/sparseimagingnufft.py
+++ b/python/priism/core/sparseimagingnufft.py
@@ -190,7 +190,7 @@ class SparseImagingExecutor(object):
         print('')
         print(' FFTW file:              {0}'.format(inputs.infile))
         if initialimage is None:
-            print(' x was initialized with 1.0')
+            print(' x was initialized with 0.0')
         else:
             print(' x was initialize by the user')
         #print ' x is saved to:          xout'

--- a/setup.py
+++ b/setup.py
@@ -228,7 +228,7 @@ class download_smili(config):
 
         is_git_ok, is_curl_ok, is_wget_ok = check_command_availability(['git', 'curl', 'wget'])
         package = 'sparseimaging'
-        commit = '5d285c54fa68ed0c006302c52b92723970a05f46'
+        commit = '4b17859f36a5766da4629271f940c759514b151c'
         zipname = '{}.zip'.format(commit)
         base_url = 'https://github.com/ikeda46/{}'.format(package)
         if is_git_ok:


### PR DESCRIPTION
Added `scalehyperparam` option to `crossvalidation` and `solve` methods for compatibility with previous version. Default for `scalehyperparam` is `True`, indicating produce compatible result with previous version. When `scalehyperparam` is `False`, resulting image for the same set of hyperparameters for L1 and TSV penalty terms will be incompatible with previous version.