### PR TITLE
Allow environment variables to change user build options?

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,12 @@ def arg_for_set_undefined_options(cmd):
 def initialize_attr_for_user_options(cmd):
     for option in cmd.user_options:
         attrname = opt2attr(option)
+        setattr(cmd, attrname, None)
+
+
+def overwrite_attr_for_user_options_by_environ(cmd):
+    for option in cmd.user_options:
+        attrname = opt2attr(option)
         envname = opt2env(option)
         setattr(cmd, attrname, os.environ.get(envname))
 
@@ -161,6 +167,7 @@ class priism_build(build):
         super(priism_build, self).initialize_options()
         self.fftw3_root_dir = None
         initialize_attr_for_user_options(self)
+        overwrite_attr_for_user_options_by_environ(self)
 
     def finalize_options(self):
         super(priism_build, self).finalize_options()

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,10 @@ def opt2attr(s):
     return s[0].strip('=').replace('-', '_')
 
 
+def opt2env(s):
+    return "PRIISM_" + opt2attr(s).upper()
+
+
 def debug_print_user_options(cmd):
     print('Command: {}'.format(cmd.__class__.__name__))
     print('User Options:')
@@ -88,7 +92,8 @@ def arg_for_set_undefined_options(cmd):
 def initialize_attr_for_user_options(cmd):
     for option in cmd.user_options:
         attrname = opt2attr(option)
-        setattr(cmd, attrname, None)
+        envname = opt2env(option)
+        setattr(cmd, attrname, os.environ.get(envname))
 
 
 def get_python_library(include_dir):


### PR DESCRIPTION
Thank you for developing PRIISM! In this PR, I would like to propose to allow users to change the PRIISM build options by setting environment variables. This would be very helpful for users who manage their Python environments by management tools (such as [Poetry](https://python-poetry.org/) and [Pipenv](https://pipenv.pypa.io/en/latest/)) and want to change the build options. For example, Poetry enables to manage PRIISM by the following specification written in `pyproject.toml`:

```toml
[tool.poetry.dependencies]
priism = { git = "https://github.com/tnakazato/priism.git", tag = "priism-0.10.0" }
```

and auto-install it (including the build step) by:

```shell
$ poetry install
```

This would be useful, however, at this moment there is no official way to pass the build options (e.g. `--use-intel-compiler yes`) to such management tools. This PR updated `setup.py` so as to set the initial values of the build options from corresponding environment variables (if they exist; otherwise set `None`). As a result of the update, the following two lines become identical:

```shell
$ python setup.py build --use-intel-compiler yes
$ PRIISM_USE_INTEL_COMPILER=yes python setup.py build
```

Note that backward compatibility is maintained because the build options always take precedence over the environment variables. The names of environment variables were designed by the following rules:

1. Replace hyphens with underscores (e.g. `use-intel-compiler` → `use_intel_compiler`)
2. Convert to upper case (→ `USE_INTEL_COMPILER`)
3. Prepend `PRIISM_` (→ `PRIISM_USE_INTEL_COMPILER`)

I would appreciate it if you could consider such possibility. Of course, please feel free to close it if the update does not fit your code or your development plan. Thank you!