### PR TITLE
Replace gpyopt with skopt

### DIFF
--- a/python/priism/core/imager.py
+++ b/python/priism/core/imager.py
@@ -738,8 +738,6 @@ class CVPlotterBase:
         assert Ltsv in self.Ltsv_list
         row = np.where(self.L1_list == L1)[0][0]
         column = np.where(self.Ltsv_list == Ltsv)[0][0]
-
-        column = np.where(self.Ltsv_list == Ltsv)[0][0]
         cx = self.outer_frame.left_margin + (column + 0.5) * self.outer_frame.dx
         cy = self.outer_frame.bottom_margin + (row + 0.5) * self.outer_frame.dy
         left = cx - self.image_width / 2

--- a/python/priism/core/imager.py
+++ b/python/priism/core/imager.py
@@ -27,7 +27,7 @@ import pickle
 import shutil
 import time
 
-import GPyOpt
+import skopt
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
@@ -560,8 +560,8 @@ class SparseModelingImager(object):
         result_image = []
 
         def __objective_function(x):
-            L1 = x[0][0]
-            Ltsv = x[0][1]
+            L1 = 10.0**x[0]
+            Ltsv = 10.0**x[1]
 
             mse, imagename = self._cv_exec(
                 L1, Ltsv, hp_scale, imageprefix, maxiter,
@@ -585,17 +585,22 @@ class SparseModelingImager(object):
 
             return mse
 
+        def list2bound(param_list):
+            pmin = int(round(math.log10(min(param_list))))
+            pmax = int(round(math.log10(max(param_list))))
+            bound = skopt.space.space.Integer(pmin, pmax, prior='uniform', base=10)
+            return bound
+
         bounds = [
-            {'name': 'var_1', 'type': 'discrete', 'domain': l1_list},
-            {'name': 'var_2', 'type': 'discrete', 'domain': ltsv_list},
+            list2bound(l1_list),
+            list2bound(ltsv_list)
         ]
 
-        problem = GPyOpt.methods.BayesianOptimization(__objective_function, bounds)
-        problem.run_optimization(bayesopt_maxiter)
-        # for debugging
-        # problem.save_evaluations('cv_eval.txt')
-        # problem.save_models('cv_model.txt')
-        # problem.save_report('cv_report.txt')
+        self.cv_bayes_result = skopt.gp_minimize(
+            __objective_function,
+            bounds,
+            n_calls=bayesopt_maxiter,
+        )
 
         return self.CrossValidationResult(
             mse=result_mse, image=result_image,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 casatasks
 casatools
 casadata
-GPyOpt
+scikit-optimize


### PR DESCRIPTION
This PR intends to replace GPyOpt with scikit-optimize (skopt) since GPyOpt is no longer maintained.