### PR TITLE
update versions for actions to be used

### DIFF
--- a/.github/workflows/monolithic-casa.yml
+++ b/.github/workflows/monolithic-casa.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install FFTW3 (Ubuntu)
       run: sudo apt install -y libfftw3-bin libfftw3-dev

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up environment variable (macOS)
       if: ${{ startsWith(matrix.os, 'macos-') }}
@@ -31,7 +31,7 @@ jobs:
         echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
To eliminate deprecation warning for Node 12 in GitHub Actions.