### PR TITLE
Update instruction for ADC servers

### DIFF
--- a/PRIISM-ADC-install_ja.md
+++ b/PRIISM-ADC-install_ja.md
@@ -1,44 +1,23 @@
 # PRIISMインストール手順書 @ADC
 
-PRIISMのインストール手順をまとめます。Pythonのバージョンは3.8とします。コンパイラはインテルコンパイラ`icpc`か、または`/usr/local/gcc`以下にインストールされたバージョンの新しい`gcc`のいずれかが利用可能です。なお、`icpc`を使う場合でも、sparseimaging以外のc++コードは常にgccを使ってコンパイルします。
+PRIISMのインストール手順をまとめます。CASAは6.6.4、 Pythonのバージョンは3.10とします。コンパイラはシステムの `gcc` (`/usr/bin/gcc`) を使います。
 
 ## PRIISM向け仮想環境の作成
 
-PRIISM専用の仮想環境を作ります。仮想環境のディレクトリは`~/pyenv/priism`としていますが、適宜読み替えてください。
+残念ながら、新システム（2024年7月〜）ではPython 3.11のみ利用可能です。CASAがPython 3.11に対応していないため、PRIISM専用の仮想環境を使ったインストールは、現時点ではできません。
+
+そこで、CASAを仮想環境とみなしてPRIISMをCASAに直接インストールすることにします。Python 3.10版のCASAを使うようにしてください。
 
 ```
-# PRIISM用の仮想環境を作ります
-python3.8 -m venv ~/pyenv/priism
-
-# 仮想環境を有効化
-source ~/pyenv/priism/bin/activate
-
-# pipをアップグレードしておきます。またwheelもインストールしておきます。
-python3 -m pip install --upgrade pip wheel
-```
-
-仮想環境を新規に作成する代わりに、CASAを仮想環境とみなしてPRIISMをCASAに直接インストールすることもできます。Python 3.8版のCASAを使うようにしてください。
-
-```
-# ADCの共有エリアからCASAを丸ごとコピー（この例では CASA 6.5.3）
-cp -r /usr/local/casa/casa-6.5.3-28-py3.8 .
+# ADCの共有エリアからCASAを丸ごとコピー（この例では CASA 6.6.4）
+cp -r /usr/local/casa/casa-6.6.4-34-py3.10.el8 .
 
 # パスを通す
 # which python3などとしてCASAにパスが通っていることを確認してください。
-export PATH=$PWD/casa-6.5.3-28-py3.8/bin:$PATH
+export PATH=$PWD/casa-6.6.4-34-py3.10.el8/bin:$PATH
 
 # pipをアップグレードしておきます。またwheelもインストールしておきます。
 python3 -m pip install --upgrade pip wheel
-```
-
-## インテルコンパイラのための設定
-
-2023年1月以降、ADCでインテルコンパイラを使うためには`LD_LIBRARY_PATH`の設定が必要になりました。詳しくは[ADCのFAQ](https://www.adc.nao.ac.jp/cgi-bin/cfw/wiki.cgi/FAQ/FAQJ?page=Intel+C%2B%2B+Compiler+%27icc%27+%A4%CE%BB%C8%CD%D1%A4%CB%A4%C4%A4%A4%A4%C6+%282023%C7%AF1%B7%EE20%B0%CA%B9%DF%29)を参照してください。
-以下はbashの場合の設定例です。
-
-```
-# bash系の場合
-export LD_LIBRARY_PATH=/usr/local/gcc/12.2/lib64:$LD_LIBRARY_PATH
 ```
 
 ## PRIISMのクローン
@@ -59,23 +38,14 @@ git pull
 
 ## PRIISMのインストール
 
-`pip`によるインストールをサポートしています。
-
-```
-python3 -m pip install .
-```
-
-まだ開発途上のため、もし上記がエラーになる、もしくは`pip`を使ったインストールに不安を感じる場合は下記の手順を試してください。
+`pip`によるインストールをサポートしていますが、動作が不安定なため現時点ではおすすめできません。`setup.py`によるインストール方法を下記に示します。
 
 ```
 # 依存パッケージのインストール
 python3 -m pip install -r requirements.txt
 
-# ビルド: インテルコンパイラを使う場合はこちらを実行
-python3 setup.py build --use-intel-compiler=yes
-
-# ビルド: gccを使う場合はこちらを実行（gccのバージョンが変わっていたら適宜変更してください）
-PATH=/usr/local/gcc/12.2/bin:$PATH python3 setup.py build 
+# ビルド
+python3 setup.py build
 
 # インストール
 python3 setup.py install


### PR DESCRIPTION
This PR intends to update installation instruction for new MDAS server operating as of July 2024. Changes include the following:

* changed base casa version to 6.6.4
* changed base python version to 3.10
* removed instruction based on python venv due to incompatible python version
* removed instruction using icpc